### PR TITLE
Fix issue - Boundary boxes during initialization

### DIFF
--- a/client/src/app/components/t-cloud/annotations/loitering-detection.component.ts
+++ b/client/src/app/components/t-cloud/annotations/loitering-detection.component.ts
@@ -94,6 +94,10 @@ export class LoiteringDetectionComponent implements OnInit {
     )
   }
 
+  ngAfterViewChecked() {
+    this.re_draw();
+  }
+
   @HostListener('window:resize', ['$event'])
   onResize(event) {
     if (window.innerWidth >= 1200) {


### PR DESCRIPTION
Using function in lifecycle hook `ngOnViewChecked{re_draw()}` to initialize boundary box when page loads